### PR TITLE
Detect 32-bit architecture i686

### DIFF
--- a/src/platform.sh
+++ b/src/platform.sh
@@ -66,6 +66,7 @@ detect_arch () {
 	'x64')		echo 'x86_64';;
 	'x86-64')	echo 'x86_64';;
 	'x86_64')	echo 'x86_64';;
+	'i686')		echo 'i386';;
 	*)		echo 'unknown'
 	esac
 }


### PR DESCRIPTION
Allow detection of 32-bit architecture i686.  Note that it transforms `uname` output `i686` into `i386` because that's how Debian likes to refer to the architecture.  Required for [this patch to Halcyon](https://github.com/mietek/halcyon/pull/45) which adds support for Debian 7 32-bit.
