### PR TITLE
Support DragonFly BSD

### DIFF
--- a/src/date.sh
+++ b/src/date.sh
@@ -1,5 +1,5 @@
 case $( uname -s ) in
-'Linux'|'FreeBSD')
+'Linux'|'FreeBSD'|'DragonFly')
 	get_date () {
 		date -u "$@" || return 0
 	}


### PR DESCRIPTION
Could it possibly be a saner option to have date be the default case instead of gdate so there the list of exceptions doesn't continue to grow?  Thanks.
