### PR TITLE
Fix HALCYON_SANDBOX_SOURCES for absolute paths

### DIFF
--- a/src/git.sh
+++ b/src/git.sh
@@ -135,9 +135,9 @@ git_acquire () {
 		fi
 		log_end "done, ${commit_hash}"
 	else
-		name=$( get_dir_name "${src_dir}/${thing}" ) || return 1
+		name=$( get_dir_name "${thing}" ) || return 1
 
-		copy_dir_over "${src_dir}/${thing}" "${dst_dir}/${name}" || return 1
+		copy_dir_over "${thing}" "${dst_dir}/${name}" || return 1
 	fi
 
 	echo "${name}"


### PR DESCRIPTION
Hi Miëtek,

I not completely sure with this change as I don't know impact of this change but I'm sure you will know.

I ran into issue when using HALCYON_SANDBOX_SOURCES with halcyon install:

```
HALCYON_SANDBOX_SOURCES=/absolute/path/to/project halcyon install
```

This caused an error:

```
-----> Creating temporary sandbox
   *** ERROR: get_dir_name: Expected existing /tmp/halcyon.FN7rrWdnCq/another-project-0.1.0.VR7uSYdc61//absolute/path/to/project
```

So it looks like the prepending of tmp dir is causing problem.

Worked perfectly when I used git repo url.

Maybe I just misunderstood something so feel free to correct me and close this PR.

Thanks,

Rene
